### PR TITLE
Fixed unpacking in SR830.trace method

### DIFF
--- a/slave/srs/sr830.py
+++ b/slave/srs/sr830.py
@@ -453,4 +453,5 @@ class SR830(InstrumentBase):
         """
         query = 'TRCA? {0}, {1}, {2}'.format(buffer, start, length)
         result = self.connection.ask(query)
-        return (float(f) for f in result.split())
+        # Result format: "1.0e-004,1.2e-004,". Strip trailing comma then split.
+        return (float(f) for f in result.strip(',').split(','))


### PR DESCRIPTION
Hi p3trus,

I fixed a small bug in the SR830 class. The `trace` method used to fail when unpacking the data points received from the instrument. Example:

```
Traceback (most recent call last):

  File "<ipython-input-56-7781939e7eb8>", line 1, in <module>
    [ch for ch in lockin.trace(1, 0)]

  File "C:\Python27\lib\site-packages\slave\sr830.py", line 455, in <genexpr>
    return (float(f) for f in result.split(','))

ValueError: invalid literal for float(): 2.441425e-004,
```

The changes are minor (see below), so you should be able to pull without any hassle.

Cheers,
Douglas.
